### PR TITLE
feature: optional validation

### DIFF
--- a/packages/scope-validator/lib/scope-validator-factory.ts
+++ b/packages/scope-validator/lib/scope-validator-factory.ts
@@ -12,16 +12,21 @@ type ScopeValidatorAsyncFunction<T> = (
   context: ScopeValidatorContext<T>
 ) => Promise<boolean>;
 
+type ScopeValidatorOption = {
+  optional?: boolean;
+};
+
 export default class ScopeValidatorFactory<T> {
-  static create<T = Record<string, string>>(
+  static create<T = Record<string, unknown>>(
     pattern: string,
-    func: ScopeValidatorFunction<T>
+    func: ScopeValidatorFunction<T>,
+    options?: ScopeValidatorOption
   ): ScopeValidator<T> {
     const CustomScopeValidator = class extends ScopeValidator<T> {
       private readonly func;
 
       constructor() {
-        super(pattern);
+        super(pattern, options?.optional ?? false);
 
         this.func = func;
       }
@@ -34,15 +39,16 @@ export default class ScopeValidatorFactory<T> {
     return new CustomScopeValidator();
   }
 
-  static createAsync<T = Record<string, string>>(
+  static createAsync<T = Record<string, unknown>>(
     pattern: string,
-    func: ScopeValidatorAsyncFunction<T>
+    func: ScopeValidatorAsyncFunction<T>,
+    options?: ScopeValidatorOption
   ): ScopeValidator<T> {
     const CustomScopeValidator = class extends ScopeValidator<T> {
       private readonly func;
 
       constructor() {
-        super(pattern);
+        super(pattern, options?.optional ?? false);
 
         this.func = func;
       }

--- a/packages/scope-validator/lib/scope-validator.ts
+++ b/packages/scope-validator/lib/scope-validator.ts
@@ -2,15 +2,27 @@ import ScopeValidatorContext from './scope-validator-context';
 import Pattern from './pattern';
 
 export default abstract class ScopeValidator<T> {
-  pattern: Pattern;
+  private readonly pattern: Pattern;
 
-  protected constructor(pattern: string | Pattern) {
+  private optional = false;
+
+  protected constructor(pattern: string | Pattern, optional = false) {
     if (pattern instanceof Pattern) this.pattern = pattern;
     else this.pattern = new Pattern(pattern);
+
+    this.optional = optional;
   }
 
   canValidate(str: string): boolean {
     return this.pattern.test(str);
+  }
+
+  getPattern(): Pattern {
+    return this.pattern;
+  }
+
+  isOptional(): boolean {
+    return this.optional;
   }
 
   abstract validate(

--- a/packages/scope-validator/test/integration/single-parameter.spec.ts
+++ b/packages/scope-validator/test/integration/single-parameter.spec.ts
@@ -36,6 +36,24 @@ const TestValidator5 = ScopeValidatorFactory.create(
   () => true
 );
 
+const OptionalValidator1 = ScopeValidatorFactory.create(
+  // eslint-disable-next-line no-template-curly-in-string
+  'validation-${test}',
+  (name, { parameters }) => parameters?.test === 'Hi',
+  {
+    optional: true,
+  }
+);
+
+const OptionalValidator2 = ScopeValidatorFactory.create(
+  // eslint-disable-next-line no-template-curly-in-string
+  'validation',
+  () => true,
+  {
+    optional: true,
+  }
+);
+
 describe('success', () => {
   it('validate scope', () => {
     const scopeValidatorManager = new ScopeValidatorManager();
@@ -108,6 +126,20 @@ describe('success', () => {
     );
 
     expect(result).toEqual([true]);
+  });
+
+  it('validate scope optional', () => {
+    const scopeValidatorManager = new ScopeValidatorManager();
+    scopeValidatorManager.use(OptionalValidator1);
+    scopeValidatorManager.use(OptionalValidator2);
+
+    const result = scopeValidatorManager.validate([
+      'validation-Hi',
+      'validation',
+      'validate',
+    ]);
+
+    expect(result).toEqual([true, true, false]);
   });
 });
 


### PR DESCRIPTION
## 관련 이슈
여러가지 validator 중 하나만 맞아도 validation이 성공하는 기능이 없음.

## 현재 상황
모든 validator를 통과해야 validation이 성공함

## 개선 방법
optional validator을 추가
* optional validator 끼리는 하나만 통과해도 validation 성공
* 모든 optional validator가 실패하면 validation 실패
* optional validator와 일반 validator 혼용 가능

## 예상 되는 부수 효과
좀더 유연한 validation 가능

## TODO
- [X] 테스트 코드 작성
- [X] 비즈니스 로직 작성
- [X] 로컬 환경에서 테스트

## Reference
없음